### PR TITLE
Stop new asset-triggered Dags from consuming historical asset events

### DIFF
--- a/airflow-core/newsfragments/27.significant.rst
+++ b/airflow-core/newsfragments/27.significant.rst
@@ -1,0 +1,8 @@
+New asset-triggered Dags no longer receive historical asset events
+
+Previously, when an asset-triggered Dag was added to a deployment whose assets
+already had event history, its first run consumed every asset event ever
+recorded for those assets. A newly added Dag now only receives events that
+occurred after it started scheduling on the asset. Although this may change the
+first run of Dags added to assets with existing history, the previous behavior
+is considered a bug (see issue #39456).

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2592,7 +2592,18 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                             ),
                         ),
                         AssetEvent.timestamp <= triggered_date,
-                        AssetEvent.timestamp > func.coalesce(cte.c.previous_dag_run_run_after, date.min),
+                        # On the first ever run there is no previous run to bound the window, so fall
+                        # back to when the Dag started scheduling on its assets. This stops a newly
+                        # added Dag from consuming the whole historical backlog of events that predate
+                        # it (#39456). created_at survives re-parsing: references are updated in place.
+                        AssetEvent.timestamp
+                        > func.coalesce(
+                            cte.c.previous_dag_run_run_after,
+                            select(func.min(DagScheduleAssetReference.created_at))
+                            .where(DagScheduleAssetReference.dag_id == dag.dag_id)
+                            .scalar_subquery(),
+                            date.min,
+                        ),
                     )
                     .order_by(AssetEvent.timestamp.asc(), AssetEvent.id.asc())
                 )

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -65,6 +65,7 @@ from airflow.models.asset import (
     AssetEvent,
     AssetModel,
     AssetPartitionDagRun,
+    DagScheduleAssetReference,
     PartitionedAssetKeyLog,
 )
 from airflow.models.backfill import Backfill, BackfillDagRun, ReprocessBehavior, _create_backfill
@@ -5501,39 +5502,20 @@ class TestSchedulerJob:
 
         with dag_maker(dag_id="assets-1", start_date=timezone.utcnow(), session=session):
             BashOperator(task_id="task", bash_command="echo 1", outlets=[asset1])
-        dr = dag_maker.create_dagrun(
+        dr1 = dag_maker.create_dagrun(
             run_id="run1",
             logical_date=(DEFAULT_DATE + timedelta(days=100)),
             data_interval=(DEFAULT_DATE + timedelta(days=10), DEFAULT_DATE + timedelta(days=11)),
         )
-
-        asset1_id = session.scalar(select(AssetModel.id).where(AssetModel.uri == asset1.uri))
-
-        event1 = AssetEvent(
-            asset_id=asset1_id,
-            source_task_id="task",
-            source_dag_id=dr.dag_id,
-            source_run_id=dr.run_id,
-            source_map_index=-1,
-        )
-        session.add(event1)
-
-        # Create a second event, creation time is more recent, but data interval is older
-        dr = dag_maker.create_dagrun(
+        dr2 = dag_maker.create_dagrun(
             run_id="run2",
             logical_date=(DEFAULT_DATE + timedelta(days=101)),
             data_interval=(DEFAULT_DATE + timedelta(days=5), DEFAULT_DATE + timedelta(days=6)),
         )
 
-        event2 = AssetEvent(
-            asset_id=asset1_id,
-            source_task_id="task",
-            source_dag_id=dr.dag_id,
-            source_run_id=dr.run_id,
-            source_map_index=-1,
-        )
-        session.add(event2)
+        asset1_id = session.scalar(select(AssetModel.id).where(AssetModel.uri == asset1.uri))
 
+        # Consumer Dags are created before the events, so the events fall within their window.
         with dag_maker(dag_id="assets-consumer-multiple", schedule=[asset1, asset2]):
             pass
         dag2 = dag_maker.dag
@@ -5541,11 +5523,38 @@ class TestSchedulerJob:
             pass
         dag3 = dag_maker.dag
 
+        base = session.scalar(
+            select(DagScheduleAssetReference.created_at).where(
+                DagScheduleAssetReference.dag_id == dag3.dag_id
+            )
+        )
+        event1 = AssetEvent(
+            asset_id=asset1_id,
+            source_task_id="task",
+            source_dag_id=dr1.dag_id,
+            source_run_id=dr1.run_id,
+            source_map_index=-1,
+            timestamp=base + timedelta(seconds=1),
+        )
+        event2 = AssetEvent(
+            asset_id=asset1_id,
+            source_task_id="task",
+            source_dag_id=dr2.dag_id,
+            source_run_id=dr2.run_id,
+            source_map_index=-1,
+            timestamp=base + timedelta(seconds=2),
+        )
+        session.add_all([event1, event2])
+
         session = dag_maker.session
         session.add_all(
             [
-                AssetDagRunQueue(asset_id=asset1_id, target_dag_id=dag2.dag_id),
-                AssetDagRunQueue(asset_id=asset1_id, target_dag_id=dag3.dag_id),
+                AssetDagRunQueue(
+                    asset_id=asset1_id, target_dag_id=dag2.dag_id, created_at=base + timedelta(hours=1)
+                ),
+                AssetDagRunQueue(
+                    asset_id=asset1_id, target_dag_id=dag3.dag_id, created_at=base + timedelta(hours=1)
+                ),
             ]
         )
         session.flush()
@@ -5590,6 +5599,65 @@ class TestSchedulerJob:
         )
 
         assert created_run.creating_job_id == scheduler_job.id
+
+    @pytest.mark.need_serialized_dag
+    def test_new_asset_triggered_dag_ignores_events_before_creation(self, session, dag_maker):
+        """A newly added asset-triggered Dag must not consume events that predate it.
+
+        Reproduces issue #39456: a new consumer Dag scheduled on an asset that already has
+        historical events should only receive events that occurred after it started
+        consuming the asset, not the entire backlog since the first event.
+        """
+        asset = Asset(uri="test://asset-historical", name="hist_asset", group="test_group")
+
+        # Producer Dag + run that the asset events are sourced from.
+        with dag_maker(dag_id="historical-producer", start_date=timezone.utcnow(), session=session):
+            BashOperator(task_id="task", bash_command="echo 1", outlets=[asset])
+        producer_run = dag_maker.create_dagrun(run_id="producer-run")
+
+        asset_id = session.scalar(select(AssetModel.id).where(AssetModel.uri == asset.uri))
+
+        # Consumer Dag created now; its schedule reference's created_at is the cut-off.
+        with dag_maker(dag_id="historical-consumer", schedule=[asset]):
+            pass
+        consumer_dag = dag_maker.dag
+        reference_created_at = session.scalar(
+            select(DagScheduleAssetReference.created_at).where(
+                DagScheduleAssetReference.dag_id == consumer_dag.dag_id
+            )
+        )
+
+        def _make_event(timestamp):
+            return AssetEvent(
+                asset_id=asset_id,
+                source_task_id="task",
+                source_dag_id=producer_run.dag_id,
+                source_run_id=producer_run.run_id,
+                source_map_index=-1,
+                timestamp=timestamp,
+            )
+
+        old_event = _make_event(reference_created_at - timedelta(days=1))
+        new_event = _make_event(reference_created_at + timedelta(seconds=1))
+        session.add_all([old_event, new_event])
+        # Trigger time after both events so neither is excluded by the upper bound.
+        session.add(
+            AssetDagRunQueue(
+                asset_id=asset_id,
+                target_dag_id=consumer_dag.dag_id,
+                created_at=reference_created_at + timedelta(hours=1),
+            )
+        )
+        session.flush()
+
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
+        with create_session() as session:
+            self.job_runner._create_dagruns_for_dags(session, session)
+
+        created_run = session.scalars(select(DagRun).where(DagRun.dag_id == consumer_dag.dag_id)).one()
+        assert created_run.state == State.QUEUED
+        assert {e.id for e in created_run.consumed_asset_events} == {new_event.id}
 
     @pytest.mark.need_serialized_dag
     def test_create_dag_runs_asset_alias_with_asset_event_attached(self, session, dag_maker):


### PR DESCRIPTION
### Problem

When an asset-triggered Dag is added to a deployment whose assets already have event history, its **first** run swept in *every* asset event ever recorded for those assets. The event-selection window in `_create_dag_runs_asset_triggered` falls back to `date.min` when there is no previous asset-triggered run, so a brand-new consumer reprocesses the entire historical backlog on its first run.

Reproduces and fixes #39456 (still open; the original fix PR #39603 was closed as stale against Airflow 2.x and never ported to 3.x).

### Fix

Bound the first run's window at the moment the Dag started scheduling on its assets — the schedule reference's `created_at`. That value is preserved across re-parsing (schedule references are updated in place in `dag_processing/collection.py`, not deleted and recreated), so it reliably means "when this Dag began consuming the asset". A new Dag now only receives events that occurred after it started consuming the asset; subsequent runs are unaffected (they're still bounded by the previous run's `run_after`).

Scope: direct asset references only. The asset-**alias** path is intentionally left unchanged — an alias consumer is expected to pick up events attached to its alias regardless of timing (`test_create_dag_runs_asset_alias_with_asset_event_attached`).

### Validation

- New regression test `test_new_asset_triggered_dag_ignores_events_before_creation` — fails on `main` (consumes 2 events), passes with the fix (consumes 1).
- Updated `test_create_dag_runs_assets`, which previously encoded the buggy behavior (events created before the consumer Dag).
- All 19 asset-related scheduler tests pass.

closes: #39456

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8, 1M context)

Generated-by: Claude Code (Opus 4.8, 1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)