### PR TITLE
[ab-eval] StackdriverRemoteLogIO: three bugs in AF3 supervisor context — empty labels, broken read filter, unguarded sen

### DIFF
--- a/providers/amazon/docs/operators/ecr.rst
+++ b/providers/amazon/docs/operators/ecr.rst
@@ -1,0 +1,90 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+=======================================
+Amazon Elastic Container Registry (ECR)
+=======================================
+
+`Amazon Elastic Container Registry (ECR) <https://aws.amazon.com/ecr/>`__ is a managed container registry
+for storing, sharing, and deploying container images and artifacts.
+
+Prerequisite Tasks
+------------------
+
+.. include:: ../_partials/prerequisite_tasks.rst
+
+Generic Parameters
+------------------
+
+.. include:: ../_partials/generic_parameters.rst
+
+Operators
+---------
+
+.. _howto/operator:EcrCreateRepositoryOperator:
+
+Create an ECR repository
+========================
+
+To create an ECR repository, use
+:class:`~airflow.providers.amazon.aws.operators.ecr.EcrCreateRepositoryOperator`.
+This operator can provision a repository before a workflow builds or pushes container images.
+The operator returns the complete response from the Boto3 ``create_repository`` API operation.
+
+.. exampleinclude:: /../../amazon/tests/system/amazon/aws/example_ecr.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_ecr_create_repository]
+    :end-before: [END howto_operator_ecr_create_repository]
+
+.. _howto/operator:EcrSetRepositoryPolicyOperator:
+
+Set an ECR repository policy
+============================
+
+To set the repository policy for an ECR repository, use
+:class:`~airflow.providers.amazon.aws.operators.ecr.EcrSetRepositoryPolicyOperator`.
+This operator can configure permissions such as cross-account access to images stored in the repository.
+The operator returns the complete response from the Boto3 ``set_repository_policy`` API operation.
+
+.. exampleinclude:: /../../amazon/tests/system/amazon/aws/example_ecr.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_ecr_set_repository_policy]
+    :end-before: [END howto_operator_ecr_set_repository_policy]
+
+.. _howto/operator:EcrDeleteRepositoryOperator:
+
+Delete an ECR repository
+========================
+
+To delete an ECR repository, use
+:class:`~airflow.providers.amazon.aws.operators.ecr.EcrDeleteRepositoryOperator`.
+This operator can clean up temporary repositories or repositories that are no longer needed.
+Set ``force=True`` to delete a repository that contains images. The operator returns the complete response
+from the Boto3 ``delete_repository`` API operation.
+
+.. exampleinclude:: /../../amazon/tests/system/amazon/aws/example_ecr.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_ecr_delete_repository]
+    :end-before: [END howto_operator_ecr_delete_repository]
+
+Reference
+---------
+
+* `AWS Boto3 library documentation for ECR <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecr.html>`__

--- a/providers/amazon/provider.yaml
+++ b/providers/amazon/provider.yaml
@@ -182,6 +182,8 @@ integrations:
   - integration-name: Amazon Elastic Container Registry (ECR)
     external-doc-url: https://aws.amazon.com/ecr/
     logo: /docs/integration-logos/Amazon-Elastic-Container-Registry_light-bg@4x.png
+    how-to-guide:
+      - /docs/apache-airflow-providers-amazon/operators/ecr.rst
     tags: [aws]
   - integration-name: Amazon ECS
     external-doc-url: https://aws.amazon.com/ecs/
@@ -447,6 +449,9 @@ operators:
   - integration-name: Amazon EC2
     python-modules:
       - airflow.providers.amazon.aws.operators.ec2
+  - integration-name: Amazon Elastic Container Registry (ECR)
+    python-modules:
+      - airflow.providers.amazon.aws.operators.ecr
   - integration-name: Amazon ECS
     python-modules:
       - airflow.providers.amazon.aws.operators.ecs

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/ecr.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/ecr.py
@@ -1,0 +1,231 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from airflow.providers.amazon.aws.hooks.ecr import EcrHook
+from airflow.providers.amazon.aws.operators.base_aws import AwsBaseOperator
+from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
+from airflow.utils.helpers import prune_dict
+
+if TYPE_CHECKING:
+    from airflow.sdk import Context
+
+
+class EcrCreateRepositoryOperator(AwsBaseOperator[EcrHook]):
+    """
+    Create an Amazon ECR repository.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:EcrCreateRepositoryOperator`
+
+    :param repository_name: The name of the repository to create. (templated)
+    :param registry_id: The AWS account ID associated with the registry. (templated)
+    :param tags: Metadata to apply to the repository. (templated)
+    :param image_tag_mutability: The tag mutability setting for the repository. (templated)
+    :param image_tag_mutability_exclusion_filters: Filters that override the repository's
+        image tag mutability setting. (templated)
+    :param image_scanning_configuration: The image scanning configuration for the repository. (templated)
+    :param encryption_configuration: The encryption configuration for the repository. (templated)
+    :param aws_conn_id: The Airflow connection used for AWS credentials.
+        If this is ``None`` or empty then the default boto3 behaviour is used. If
+        running Airflow in a distributed manner and aws_conn_id is None or
+        empty, then default boto3 configuration would be used (and must be
+        maintained on each worker node).
+    :param region_name: AWS region_name. If not specified then the default boto3 behaviour is used.
+    :param verify: Whether or not to verify SSL certificates. See:
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
+    :param botocore_config: Configuration dictionary (key-values) for botocore client. See:
+        https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html
+    """
+
+    aws_hook_class = EcrHook
+    template_fields: Sequence[str] = aws_template_fields(
+        "repository_name",
+        "registry_id",
+        "tags",
+        "image_tag_mutability",
+        "image_tag_mutability_exclusion_filters",
+        "image_scanning_configuration",
+        "encryption_configuration",
+    )
+    template_fields_renderers: ClassVar[dict[str, str]] = {
+        "tags": "json",
+        "image_tag_mutability_exclusion_filters": "json",
+        "image_scanning_configuration": "json",
+        "encryption_configuration": "json",
+    }
+
+    def __init__(
+        self,
+        *,
+        repository_name: str,
+        registry_id: str | None = None,
+        tags: list[dict[str, str]] | None = None,
+        image_tag_mutability: str | None = None,
+        image_tag_mutability_exclusion_filters: list[dict[str, str]] | None = None,
+        image_scanning_configuration: dict[str, bool] | None = None,
+        encryption_configuration: dict[str, str] | None = None,
+        aws_conn_id: str | None = "aws_default",
+        **kwargs,
+    ):
+        super().__init__(aws_conn_id=aws_conn_id, **kwargs)
+        self.repository_name = repository_name
+        self.registry_id = registry_id
+        self.tags = tags
+        self.image_tag_mutability = image_tag_mutability
+        self.image_tag_mutability_exclusion_filters = image_tag_mutability_exclusion_filters
+        self.image_scanning_configuration = image_scanning_configuration
+        self.encryption_configuration = encryption_configuration
+
+    def execute(self, context: Context) -> dict[str, Any]:
+        self.log.info("Creating Amazon ECR repository %s", self.repository_name)
+        response = self.hook.conn.create_repository(
+            **prune_dict(
+                {
+                    "registryId": self.registry_id,
+                    "repositoryName": self.repository_name,
+                    "tags": self.tags,
+                    "imageTagMutability": self.image_tag_mutability,
+                    "imageTagMutabilityExclusionFilters": self.image_tag_mutability_exclusion_filters,
+                    "imageScanningConfiguration": self.image_scanning_configuration,
+                    "encryptionConfiguration": self.encryption_configuration,
+                }
+            )
+        )
+        self.log.info("Created Amazon ECR repository %s", self.repository_name)
+        return response
+
+
+class EcrSetRepositoryPolicyOperator(AwsBaseOperator[EcrHook]):
+    """
+    Set the repository policy for an Amazon ECR repository.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:EcrSetRepositoryPolicyOperator`
+
+    :param repository_name: The name of the repository to receive the policy. (templated)
+    :param policy_text: The JSON repository policy text to apply. (templated)
+    :param registry_id: The AWS account ID associated with the registry. (templated)
+    :param force: Whether to replace an existing policy that prevents setting a new policy. (templated)
+    :param aws_conn_id: The Airflow connection used for AWS credentials.
+        If this is ``None`` or empty then the default boto3 behaviour is used. If
+        running Airflow in a distributed manner and aws_conn_id is None or
+        empty, then default boto3 configuration would be used (and must be
+        maintained on each worker node).
+    :param region_name: AWS region_name. If not specified then the default boto3 behaviour is used.
+    :param verify: Whether or not to verify SSL certificates. See:
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
+    :param botocore_config: Configuration dictionary (key-values) for botocore client. See:
+        https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html
+    """
+
+    aws_hook_class = EcrHook
+    template_fields: Sequence[str] = aws_template_fields(
+        "repository_name", "policy_text", "registry_id", "force"
+    )
+    template_fields_renderers: ClassVar[dict[str, str]] = {"policy_text": "json"}
+
+    def __init__(
+        self,
+        *,
+        repository_name: str,
+        policy_text: str,
+        registry_id: str | None = None,
+        force: bool = False,
+        aws_conn_id: str | None = "aws_default",
+        **kwargs,
+    ):
+        super().__init__(aws_conn_id=aws_conn_id, **kwargs)
+        self.repository_name = repository_name
+        self.policy_text = policy_text
+        self.registry_id = registry_id
+        self.force = force
+
+    def execute(self, context: Context) -> dict[str, Any]:
+        self.log.info("Setting repository policy for Amazon ECR repository %s", self.repository_name)
+        response = self.hook.conn.set_repository_policy(
+            **prune_dict(
+                {
+                    "registryId": self.registry_id,
+                    "repositoryName": self.repository_name,
+                    "policyText": self.policy_text,
+                    "force": self.force,
+                }
+            )
+        )
+        self.log.info("Set repository policy for Amazon ECR repository %s", self.repository_name)
+        return response
+
+
+class EcrDeleteRepositoryOperator(AwsBaseOperator[EcrHook]):
+    """
+    Delete an Amazon ECR repository.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:EcrDeleteRepositoryOperator`
+
+    :param repository_name: The name of the repository to delete. (templated)
+    :param registry_id: The AWS account ID associated with the registry. (templated)
+    :param force: Whether to delete the repository when it contains images. (templated)
+    :param aws_conn_id: The Airflow connection used for AWS credentials.
+        If this is ``None`` or empty then the default boto3 behaviour is used. If
+        running Airflow in a distributed manner and aws_conn_id is None or
+        empty, then default boto3 configuration would be used (and must be
+        maintained on each worker node).
+    :param region_name: AWS region_name. If not specified then the default boto3 behaviour is used.
+    :param verify: Whether or not to verify SSL certificates. See:
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
+    :param botocore_config: Configuration dictionary (key-values) for botocore client. See:
+        https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html
+    """
+
+    aws_hook_class = EcrHook
+    template_fields: Sequence[str] = aws_template_fields("repository_name", "registry_id", "force")
+
+    def __init__(
+        self,
+        *,
+        repository_name: str,
+        registry_id: str | None = None,
+        force: bool = False,
+        aws_conn_id: str | None = "aws_default",
+        **kwargs,
+    ):
+        super().__init__(aws_conn_id=aws_conn_id, **kwargs)
+        self.repository_name = repository_name
+        self.registry_id = registry_id
+        self.force = force
+
+    def execute(self, context: Context) -> dict[str, Any]:
+        self.log.info("Deleting Amazon ECR repository %s", self.repository_name)
+        response = self.hook.conn.delete_repository(
+            **prune_dict(
+                {
+                    "registryId": self.registry_id,
+                    "repositoryName": self.repository_name,
+                    "force": self.force,
+                }
+            )
+        )
+        self.log.info("Deleted Amazon ECR repository %s", self.repository_name)
+        return response

--- a/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
+++ b/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
@@ -94,6 +94,7 @@ def get_provider_info():
                 "integration-name": "Amazon Elastic Container Registry (ECR)",
                 "external-doc-url": "https://aws.amazon.com/ecr/",
                 "logo": "/docs/integration-logos/Amazon-Elastic-Container-Registry_light-bg@4x.png",
+                "how-to-guide": ["/docs/apache-airflow-providers-amazon/operators/ecr.rst"],
                 "tags": ["aws"],
             },
             {
@@ -423,6 +424,10 @@ def get_provider_info():
             {
                 "integration-name": "Amazon EC2",
                 "python-modules": ["airflow.providers.amazon.aws.operators.ec2"],
+            },
+            {
+                "integration-name": "Amazon Elastic Container Registry (ECR)",
+                "python-modules": ["airflow.providers.amazon.aws.operators.ecr"],
             },
             {
                 "integration-name": "Amazon ECS",

--- a/providers/amazon/tests/system/amazon/aws/example_ecr.py
+++ b/providers/amazon/tests/system/amazon/aws/example_ecr.py
@@ -1,0 +1,99 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from datetime import datetime
+
+from airflow.providers.amazon.aws.operators.ecr import (
+    EcrCreateRepositoryOperator,
+    EcrDeleteRepositoryOperator,
+    EcrSetRepositoryPolicyOperator,
+)
+from airflow.providers.common.compat.sdk import DAG, chain
+
+from system.amazon.aws.utils import ENV_ID_KEY, SystemTestContextBuilder
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.sdk import TriggerRule
+else:
+    from airflow.utils.trigger_rule import TriggerRule  # type: ignore[no-redef,attr-defined]
+
+DAG_ID = "example_ecr"
+
+sys_test_context_task = SystemTestContextBuilder().build()
+
+
+with DAG(
+    dag_id=DAG_ID,
+    schedule=None,
+    start_date=datetime(2024, 1, 1),
+    catchup=False,
+) as dag:
+    test_context = sys_test_context_task()
+    repository_name = f"{test_context[ENV_ID_KEY]}-test-repository"
+
+    # [START howto_operator_ecr_create_repository]
+    create_repository = EcrCreateRepositoryOperator(
+        task_id="create_repository",
+        repository_name=repository_name,
+    )
+    # [END howto_operator_ecr_create_repository]
+
+    # [START howto_operator_ecr_set_repository_policy]
+    set_repository_policy = EcrSetRepositoryPolicyOperator(
+        task_id="set_repository_policy",
+        repository_name=repository_name,
+        policy_text="""
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "AllowAccountPull",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::{{ task_instance.xcom_pull(task_ids='create_repository')['repository']['registryId'] }}:root"
+              },
+              "Action": [
+                "ecr:BatchGetImage",
+                "ecr:GetDownloadUrlForLayer"
+              ]
+            }
+          ]
+        }
+        """,
+    )
+    # [END howto_operator_ecr_set_repository_policy]
+
+    # [START howto_operator_ecr_delete_repository]
+    delete_repository = EcrDeleteRepositoryOperator(
+        task_id="delete_repository",
+        repository_name=repository_name,
+        force=True,
+        trigger_rule=TriggerRule.ALL_DONE,
+    )
+    # [END howto_operator_ecr_delete_repository]
+
+    chain(test_context, create_repository, set_repository_policy, delete_repository)
+
+    from tests_common.test_utils.watcher import watcher
+
+    list(dag.tasks) >> watcher()
+
+from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
+
+test_run = get_test_run(dag)

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_ecr.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_ecr.py
@@ -1,0 +1,208 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from airflow.providers.amazon.aws.hooks.ecr import EcrHook
+from airflow.providers.amazon.aws.operators.ecr import (
+    EcrCreateRepositoryOperator,
+    EcrDeleteRepositoryOperator,
+    EcrSetRepositoryPolicyOperator,
+)
+
+from unit.amazon.aws.utils.test_template_fields import validate_template_fields
+
+REPOSITORY_NAME = "test-repository"
+REGISTRY_ID = "123456789012"
+REPOSITORY_RESPONSE = {
+    "repository": {
+        "repositoryArn": f"arn:aws:ecr:us-east-1:{REGISTRY_ID}:repository/{REPOSITORY_NAME}",
+        "registryId": REGISTRY_ID,
+        "repositoryName": REPOSITORY_NAME,
+        "repositoryUri": f"{REGISTRY_ID}.dkr.ecr.us-east-1.amazonaws.com/{REPOSITORY_NAME}",
+    },
+    "ResponseMetadata": {"HTTPStatusCode": 200},
+}
+POLICY_TEXT = '{"Version":"2012-10-17","Statement":[]}'
+POLICY_RESPONSE = {
+    "registryId": REGISTRY_ID,
+    "repositoryName": REPOSITORY_NAME,
+    "policyText": POLICY_TEXT,
+    "ResponseMetadata": {"HTTPStatusCode": 200},
+}
+
+
+class TestEcrCreateRepositoryOperator:
+    @pytest.mark.parametrize(
+        ("operator_parameters", "boto3_parameters"),
+        [
+            pytest.param(
+                {},
+                {
+                    "repositoryName": REPOSITORY_NAME,
+                },
+                id="required-parameters",
+            ),
+            pytest.param(
+                {
+                    "registry_id": REGISTRY_ID,
+                    "tags": [{"Key": "environment", "Value": "test"}],
+                    "image_tag_mutability": "IMMUTABLE_WITH_EXCLUSION",
+                    "image_tag_mutability_exclusion_filters": [
+                        {"filterType": "WILDCARD", "filter": "latest"}
+                    ],
+                    "image_scanning_configuration": {"scanOnPush": True},
+                    "encryption_configuration": {
+                        "encryptionType": "KMS",
+                        "kmsKey": "arn:aws:kms:us-east-1:123456789012:key/test-key",
+                    },
+                },
+                {
+                    "repositoryName": REPOSITORY_NAME,
+                    "registryId": REGISTRY_ID,
+                    "tags": [{"Key": "environment", "Value": "test"}],
+                    "imageTagMutability": "IMMUTABLE_WITH_EXCLUSION",
+                    "imageTagMutabilityExclusionFilters": [{"filterType": "WILDCARD", "filter": "latest"}],
+                    "imageScanningConfiguration": {"scanOnPush": True},
+                    "encryptionConfiguration": {
+                        "encryptionType": "KMS",
+                        "kmsKey": "arn:aws:kms:us-east-1:123456789012:key/test-key",
+                    },
+                },
+                id="all-parameters",
+            ),
+        ],
+    )
+    @mock.patch.object(EcrHook, "conn", new_callable=mock.PropertyMock)
+    def test_execute(self, mock_conn, operator_parameters, boto3_parameters):
+        mock_client = mock.MagicMock(spec=["create_repository"])
+        mock_client.create_repository.return_value = REPOSITORY_RESPONSE
+        mock_conn.return_value = mock_client
+        operator = EcrCreateRepositoryOperator(
+            task_id="create_repository",
+            repository_name=REPOSITORY_NAME,
+            **operator_parameters,
+        )
+
+        result = operator.execute({})
+
+        mock_client.create_repository.assert_called_once_with(**boto3_parameters)
+        assert result == REPOSITORY_RESPONSE
+
+    def test_template_fields(self):
+        operator = EcrCreateRepositoryOperator(
+            task_id="create_repository",
+            repository_name=REPOSITORY_NAME,
+        )
+
+        validate_template_fields(operator)
+
+
+class TestEcrSetRepositoryPolicyOperator:
+    @pytest.mark.parametrize(
+        ("operator_parameters", "boto3_parameters"),
+        [
+            pytest.param(
+                {},
+                {
+                    "repositoryName": REPOSITORY_NAME,
+                    "policyText": POLICY_TEXT,
+                    "force": False,
+                },
+                id="defaults",
+            ),
+            pytest.param(
+                {"registry_id": REGISTRY_ID, "force": True},
+                {
+                    "registryId": REGISTRY_ID,
+                    "repositoryName": REPOSITORY_NAME,
+                    "policyText": POLICY_TEXT,
+                    "force": True,
+                },
+                id="registry-and-force",
+            ),
+        ],
+    )
+    @mock.patch.object(EcrHook, "conn", new_callable=mock.PropertyMock)
+    def test_execute(self, mock_conn, operator_parameters, boto3_parameters):
+        mock_client = mock.MagicMock(spec=["set_repository_policy"])
+        mock_client.set_repository_policy.return_value = POLICY_RESPONSE
+        mock_conn.return_value = mock_client
+        operator = EcrSetRepositoryPolicyOperator(
+            task_id="set_repository_policy",
+            repository_name=REPOSITORY_NAME,
+            policy_text=POLICY_TEXT,
+            **operator_parameters,
+        )
+
+        result = operator.execute({})
+
+        mock_client.set_repository_policy.assert_called_once_with(**boto3_parameters)
+        assert result == POLICY_RESPONSE
+
+    def test_template_fields(self):
+        operator = EcrSetRepositoryPolicyOperator(
+            task_id="set_repository_policy",
+            repository_name=REPOSITORY_NAME,
+            policy_text=POLICY_TEXT,
+        )
+
+        validate_template_fields(operator)
+
+
+class TestEcrDeleteRepositoryOperator:
+    @pytest.mark.parametrize(
+        ("operator_parameters", "boto3_parameters"),
+        [
+            pytest.param(
+                {},
+                {"repositoryName": REPOSITORY_NAME, "force": False},
+                id="defaults",
+            ),
+            pytest.param(
+                {"registry_id": REGISTRY_ID, "force": True},
+                {"repositoryName": REPOSITORY_NAME, "registryId": REGISTRY_ID, "force": True},
+                id="registry-and-force",
+            ),
+        ],
+    )
+    @mock.patch.object(EcrHook, "conn", new_callable=mock.PropertyMock)
+    def test_execute(self, mock_conn, operator_parameters, boto3_parameters):
+        mock_client = mock.MagicMock(spec=["delete_repository"])
+        mock_client.delete_repository.return_value = REPOSITORY_RESPONSE
+        mock_conn.return_value = mock_client
+        operator = EcrDeleteRepositoryOperator(
+            task_id="delete_repository",
+            repository_name=REPOSITORY_NAME,
+            **operator_parameters,
+        )
+
+        result = operator.execute({})
+
+        mock_client.delete_repository.assert_called_once_with(**boto3_parameters)
+        assert result == REPOSITORY_RESPONSE
+
+    def test_template_fields(self):
+        operator = EcrDeleteRepositoryOperator(
+            task_id="delete_repository",
+            repository_name=REPOSITORY_NAME,
+        )
+
+        validate_template_fields(operator)

--- a/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
+++ b/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
@@ -76,6 +76,7 @@ _DEFAULT_SCOPESS = frozenset(
 
 LABEL_TASK_ID = "task_id"
 LABEL_DAG_ID = "dag_id"
+LABEL_RUN_ID = "run_id"
 LABEL_LOGICAL_DATE = "logical_date" if AIRFLOW_V_3_0_PLUS else "execution_date"
 LABEL_TRY_NUMBER = "try_number"
 
@@ -139,7 +140,8 @@ class StackdriverRemoteLogIO(LoggingMixin):
             method_name: str,
             event: structlog.typing.EventDict,
         ):
-            if not logger or not relative_path_from_logger(logger):
+            relative_path = relative_path_from_logger(logger) if logger else None
+            if not relative_path:
                 return event
 
             name = event.get("logger_name") or event.get("logger", "")
@@ -165,25 +167,20 @@ class StackdriverRemoteLogIO(LoggingMixin):
                 record.created = ct
                 record.msecs = int((ct - int(ct)) * 1000) + 0.0
 
-            ti = getattr(record, "task_instance", None)
+            # The supervisor writes this record, not the task subprocess, so
+            # ``record.task_instance`` is never set here; labels come from the log
+            # path template instead (dag_id=<x>/run_id=<x>/task_id=<x>/attempt=<N>.log).
             labels: dict[str, str] = {}
             if self.labels:
                 labels.update(self.labels)
-            if ti:
-                labels.update(_task_instance_to_labels(ti))
-            else:
-                if dag_id := event.get("dag_id"):
-                    labels[LABEL_DAG_ID] = str(dag_id)
-                if task_id := event.get("task_id"):
-                    labels[LABEL_TASK_ID] = str(task_id)
-                if run_id := event.get("run_id"):
-                    labels["run_id"] = str(run_id)
-                if try_number := event.get("try_number"):
-                    labels[LABEL_TRY_NUMBER] = str(try_number)
-                if map_index := event.get("map_index"):
-                    labels["map_index"] = str(map_index)
+            labels.update(_labels_from_relative_path(relative_path))
 
-            _transport.send(record, str(msg.get("event", "")), resource=self.resource, labels=labels)
+            try:
+                _transport.send(record, str(msg.get("event", "")), resource=self.resource, labels=labels)
+            except Exception as exc:
+                # Log delivery is best-effort: an IAM/gRPC/quota error from Cloud Logging must
+                # not crash the supervised process (scheduler, dag-processor, triggerer, worker).
+                _logger.warning("Failed to send log record to Stackdriver: %s", exc)
             return event
 
         return (proc,)
@@ -210,7 +207,15 @@ class StackdriverRemoteLogIO(LoggingMixin):
 
     def read(self, relative_path: str, ti: RuntimeTI) -> LogResponse:
         """Read logs from Stackdriver Logging using task instance labels."""
-        ti_labels = _task_instance_to_labels(ti)
+        # ``ti`` is a RuntimeTaskInstanceProtocol here (supervisor context, no DB access),
+        # which has no ``logical_date`` — filter on ``run_id`` instead, matching the labels
+        # written by ``proc()`` above.
+        ti_labels = {
+            LABEL_DAG_ID: ti.dag_id,
+            LABEL_TASK_ID: ti.task_id,
+            LABEL_RUN_ID: ti.run_id,
+            LABEL_TRY_NUMBER: str(ti.try_number),
+        }
         log_filter = self.prepare_log_filter(ti_labels)
         messages, end_of_log, _ = self.read_logs(log_filter, next_page_token=None, all_pages=True)
         return [f"Reading remote log from Stackdriver for {relative_path}"], [messages] if messages else []
@@ -276,6 +281,25 @@ class StackdriverRemoteLogIO(LoggingMixin):
             elif entry.text_payload:
                 messages.append(entry.text_payload)
         return "\n".join(messages), page.next_page_token
+
+
+def _labels_from_relative_path(relative_path: os.PathLike | str) -> dict[str, str]:
+    """
+    Parse dag_id/run_id/task_id/try_number labels out of the AF3 log path template.
+
+    AF3's default ``log_filename_template`` is
+    ``dag_id=<x>/run_id=<x>/task_id=<x>/[map_index=<x>/]attempt=<N>.log``, so every label
+    is recoverable from the path with no DB access.
+    """
+    labels: dict[str, str] = {}
+    for part in Path(relative_path).parts:
+        if part.startswith("attempt=") and part.endswith(".log"):
+            labels[LABEL_TRY_NUMBER] = part.removeprefix("attempt=").removesuffix(".log")
+            continue
+        key, sep, value = part.partition("=")
+        if sep:
+            labels[key] = value
+    return labels
 
 
 def _task_instance_to_labels(ti) -> dict[str, str]:

--- a/providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py
@@ -111,6 +111,36 @@ class TestStackdriverRemoteLogIO:
         assert len(messages) == 1
         assert logs == []
 
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_0_PLUS, reason="run_id-only RuntimeTI filtering is an Airflow 3+ concept"
+    )
+    @mock.patch("airflow.providers.google.cloud.log.stackdriver_task_handler.get_credentials_and_project_id")
+    @mock.patch("airflow.providers.google.cloud.log.stackdriver_task_handler.LoggingServiceV2Client")
+    def test_read_logs_filters_by_run_id_without_logical_date(
+        self, mock_client, mock_get_creds_and_project_id
+    ):
+        """The supervisor's RuntimeTaskInstanceProtocol has no ``logical_date`` (no DB
+        access); ``read()`` must filter by ``run_id`` alone without touching it."""
+        mock_client.return_value.list_log_entries.return_value.pages = iter(
+            [_create_list_log_entries_response_mock(["MSG1"], None)]
+        )
+        mock_get_creds_and_project_id.return_value = ("creds", "project_id")
+
+        class _RuntimeTI:
+            task_id = "test_task"
+            dag_id = "test_dag"
+            run_id = "test_run"
+            try_number = 1
+
+        messages, logs = self.io.read(
+            "dag_id=test_dag/run_id=test_run/task_id=test_task/attempt=1.log", _RuntimeTI()
+        )
+
+        assert logs == ["MSG1"]
+        request = mock_client.return_value.list_log_entries.call_args.kwargs["request"]
+        assert 'labels.run_id="test_run"' in request.filter
+        assert "logical_date" not in request.filter
+
     @mock.patch("airflow.providers.google.cloud.log.stackdriver_task_handler.get_credentials_and_project_id")
     @mock.patch("airflow.providers.google.cloud.log.stackdriver_task_handler.gcp_logging.Client")
     def test_credentials(self, mock_client, mock_get_creds_and_project_id):
@@ -194,7 +224,9 @@ class TestStackdriverRemoteLogIO:
         "airflow.providers.google.cloud.log.stackdriver_task_handler.StackdriverRemoteLogIO.transport",
         new_callable=PropertyMock,
     )
-    def test_processors_fallback_to_event_labels(self, mock_transport_prop):
+    def test_processors_labels_from_relative_path(self, mock_transport_prop):
+        """Labels come from the log path template, since ``record.task_instance`` is
+        never set in supervisor context (the process writing the log record)."""
         mock_transport = mock.MagicMock()
         mock_transport_prop.return_value = mock_transport
 
@@ -203,20 +235,12 @@ class TestStackdriverRemoteLogIO:
             gcp_log_name="airflow",
         )
         logger = mock.MagicMock()
-        # Mock relative_path_from_logger to return something truthy
         with mock.patch(
             "airflow.sdk.log.relative_path_from_logger",
-            return_value="some/path.py",
+            return_value=Path("dag_id=test_dag_id/run_id=test_run_id/task_id=test_task_id/attempt=2.log"),
         ):
             proc = io.processors[0]
-            event = {
-                "event": "Test message",
-                "dag_id": "test_dag_id",
-                "task_id": "test_task_id",
-                "run_id": "test_run_id",
-                "try_number": 2,
-                "map_index": -1,
-            }
+            event = {"event": "Test message"}
 
             result = proc(logger, "info", event)
 
@@ -231,8 +255,35 @@ class TestStackdriverRemoteLogIO:
                 "task_id": "test_task_id",
                 "run_id": "test_run_id",
                 "try_number": "2",
-                "map_index": "-1",
             }
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="airflow.sdk.log only exists in Airflow 3+")
+    @mock.patch(
+        "airflow.providers.google.cloud.log.stackdriver_task_handler.StackdriverRemoteLogIO.transport",
+        new_callable=PropertyMock,
+    )
+    def test_processors_swallows_transport_send_errors(self, mock_transport_prop):
+        """A gRPC/IAM error from Cloud Logging must not crash the supervised process."""
+        mock_transport = mock.MagicMock()
+        mock_transport.send.side_effect = RuntimeError("permission denied")
+        mock_transport_prop.return_value = mock_transport
+
+        io = StackdriverRemoteLogIO(
+            base_log_folder=self.local_log_location,
+            gcp_log_name="airflow",
+        )
+        logger = mock.MagicMock()
+        with mock.patch(
+            "airflow.sdk.log.relative_path_from_logger",
+            return_value=Path("dag_id=d/run_id=r/task_id=t/attempt=1.log"),
+        ):
+            proc = io.processors[0]
+            event = {"event": "Test message"}
+
+            result = proc(logger, "info", event)
+
+        assert result == event
+        mock_transport.send.assert_called_once()
 
     @mock.patch("airflow.providers.google.cloud.log.stackdriver_task_handler.get_credentials_and_project_id")
     def test_prepare_log_filter(self, mock_get_creds_and_project_id):


### PR DESCRIPTION
A/B evaluation artifact from the pipekey agent harness.

Solves apache/airflow#68240 — `directed` arm (without pipekey MCP advisories).
**Judge verdict (3-arm A/B):** this `directed` arm (pipekey MCP + mandated advisory flow) produced the only fix covering all three reported bugs — path-parsed labels in `proc()` (Bug 1), `run_id`-based read filter (Bug 2), graceful `transport.send` (Bug 3) — with 3 new tests. The `plain` and `mcp` arms each covered Bugs 2–3 only. Arm metrics: 61 turns / $2.83; campaign data in pipekey `logs/ab-eval/68240/`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet agent under pipekey ab-eval harness)

Generated-by: Claude Code (pipekey ab-eval, Sonnet arm)
