### PR TITLE
Attribute audit log entries from the route, not the request body

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/backfills.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/backfills.py
@@ -281,8 +281,8 @@ def cancel_backfill(backfill_id: NonNegativeInt, session: SessionDep) -> Backfil
         ]
     ),
     dependencies=[
-        Depends(action_logging()),
         Depends(requires_access_backfill(method="POST")),
+        Depends(action_logging(body_attribution_fields=("dag_id",))),
     ],
 )
 def create_backfill(

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -454,7 +454,7 @@ def clear_dag_runs(
     responses=create_openapi_http_exception_doc([status.HTTP_400_BAD_REQUEST, status.HTTP_404_NOT_FOUND]),
     dependencies=[
         Depends(requires_access_dag(method="PUT", access_entity=DagAccessEntity.RUN)),
-        Depends(action_logging()),
+        Depends(action_logging(body_attribution_fields=("run_id",))),
     ],
 )
 def clear_dag_run_partitions(
@@ -732,7 +732,7 @@ def get_dag_runs(
     ),
     dependencies=[
         Depends(requires_access_dag(method="POST", access_entity=DagAccessEntity.RUN)),
-        Depends(action_logging()),
+        Depends(action_logging(body_attribution_fields=("dag_run_id",))),
     ],
 )
 def trigger_dag_run(

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
@@ -841,8 +841,8 @@ def get_mapped_task_instance_try_details(
     "/clearTaskInstances",
     responses=create_openapi_http_exception_doc([status.HTTP_404_NOT_FOUND, status.HTTP_409_CONFLICT]),
     dependencies=[
-        Depends(action_logging()),
         Depends(requires_access_dag(method="PUT", access_entity=DagAccessEntity.TASK_INSTANCE)),
+        Depends(action_logging(body_attribution_fields=("dag_run_id",))),
     ],
 )
 def post_clear_task_instances(

--- a/airflow-core/src/airflow/api_fastapi/logging/decorators.py
+++ b/airflow-core/src/airflow/api_fastapi/logging/decorators.py
@@ -138,7 +138,7 @@ def _mask_variable_entity(extra_fields):
     return result
 
 
-def action_logging(event: str | None = None):
+def action_logging(event: str | None = None, *, body_attribution_fields: tuple[str, ...] = ()):
     async def log_action(
         request: Request,
         session: SessionDep,
@@ -206,6 +206,20 @@ def action_logging(event: str | None = None):
 
         extra_fields["method"] = request.method
 
+        # The audit log is read back under per-Dag access control (see requires_access_event_log),
+        # so the attribution columns must not be settable from attacker-supplied request input:
+        # otherwise any authenticated user could forge an entry for a Dag they cannot access by naming
+        # these keys in a JSON body -- or appending them to the query string -- on a route whose schema
+        # never declared them. Take the columns from the route's path params (fixed by the URL
+        # template), and only from the specific body fields a route opts into via
+        # ``body_attribution_fields``. The full (masked) body is still recorded in ``extra``.
+        attribution = {**request.path_params}
+        for field in body_attribution_fields:
+            # A path param is fixed by the URL template and authoritative; an opted-in body field
+            # only fills a column the path does not already carry -- it must never override one.
+            if field not in attribution and field in masked_body_json:
+                attribution[field] = masked_body_json[field]
+
         # Create log entry
         log = Log(
             event=event_name,
@@ -213,9 +227,9 @@ def action_logging(event: str | None = None):
             owner=user_name,
             owner_display_name=user_display,
             extra=json.dumps(extra_fields),
-            task_id=params.get("task_id"),
-            dag_id=params.get("dag_id"),
-            run_id=params.get("run_id") or params.get("dag_run_id"),
+            task_id=attribution.get("task_id"),
+            dag_id=attribution.get("dag_id"),
+            run_id=attribution.get("run_id") or attribution.get("dag_run_id"),
         )
 
         if "logical_date" in request.query_params:

--- a/airflow-core/tests/unit/api_fastapi/logging/test_decorators.py
+++ b/airflow-core/tests/unit/api_fastapi/logging/test_decorators.py
@@ -303,3 +303,110 @@ class TestActionLoggingUserFields:
         (logged,) = session.add.call_args.args
         assert logged.owner == "jdoe"
         assert logged.owner_display_name == "Jane Doe"
+
+
+class _FakeUser(BaseUser):
+    def get_id(self) -> str:
+        return "id"
+
+    def get_name(self) -> str:
+        return "jdoe"
+
+    def get_display_name(self) -> str:
+        return "Jane Doe"
+
+
+def _run_action_logging(event, *, path_params=None, query_string=b"", body=None, body_attribution_fields=()):
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "headers": [(b"content-type", b"application/json")] if body is not None else [],
+        "query_string": query_string,
+        "path_params": path_params or {},
+    }
+    if body is None:
+        request = Request(scope)
+    else:
+        body_bytes = json.dumps(body).encode()
+
+        async def receive():
+            return {"type": "http.request", "body": body_bytes, "more_body": False}
+
+        request = Request(scope, receive=receive)
+
+    session = MagicMock(spec=Session)
+    asyncio.run(
+        action_logging(event=event, body_attribution_fields=body_attribution_fields)(
+            request=request, session=session, user=_FakeUser()
+        )
+    )
+    (logged,) = session.add.call_args.args
+    return logged
+
+
+class TestActionLoggingAttribution:
+    """The audit Log's ``dag_id`` / ``task_id`` / ``run_id`` columns gate per-Dag read access,
+    so the free-form request body must not be able to set them. They come from the route's
+    path/query params, plus only the body fields a route explicitly opts into."""
+
+    def test_body_cannot_set_attribution_columns_without_optin(self):
+        logged = _run_action_logging(
+            "post_variable_like_event",
+            body={"dag_id": "finance_etl", "task_id": "payout", "run_id": "manual__2026", "foo": "bar"},
+        )
+        assert logged.dag_id is None
+        assert logged.task_id is None
+        assert logged.run_id is None
+        # the body is still recorded verbatim in ``extra`` for forensics, just not in the columns
+        assert "finance_etl" in logged.extra
+
+    def test_attribution_columns_come_from_path_params(self):
+        logged = _run_action_logging(
+            "test_event",
+            path_params={"dag_id": "real_dag", "task_id": "real_task", "run_id": "real_run"},
+        )
+        assert logged.dag_id == "real_dag"
+        assert logged.task_id == "real_task"
+        assert logged.run_id == "real_run"
+
+    def test_query_string_cannot_set_attribution_columns(self):
+        # Undeclared query params are ignored by the route but still readable here; the URL is
+        # attacker-supplied on any route, so the query string must not feed the columns either.
+        logged = _run_action_logging(
+            "test_event",
+            query_string=b"dag_id=finance_etl&task_id=payout&run_id=manual__2026",
+        )
+        assert logged.dag_id is None
+        assert logged.task_id is None
+        assert logged.run_id is None
+
+    def test_opted_in_body_field_populates_column(self):
+        logged = _run_action_logging(
+            "post_clear_task_instances",
+            path_params={"dag_id": "real_dag"},
+            body={"dag_run_id": "body_run", "dry_run": False},
+            body_attribution_fields=("dag_run_id",),
+        )
+        assert logged.dag_id == "real_dag"
+        assert logged.run_id == "body_run"
+
+    def test_opted_in_body_field_cannot_override_the_same_path_param(self):
+        logged = _run_action_logging(
+            "some_event",
+            path_params={"dag_run_id": "path_run"},
+            body={"dag_run_id": "body_run"},
+            body_attribution_fields=("dag_run_id",),
+        )
+        # even opted in, the body must not overwrite the authoritative path value
+        assert logged.run_id == "path_run"
+
+    def test_opt_in_does_not_let_body_override_a_path_param(self):
+        logged = _run_action_logging(
+            "create_backfill",
+            path_params={"dag_id": "path_dag"},
+            body={"dag_id": "body_dag", "dag_run_id": "body_run"},
+            body_attribution_fields=("dag_run_id",),
+        )
+        # ``dag_id`` was not opted in, so the body value is ignored and the path value stands
+        assert logged.dag_id == "path_dag"
+        assert logged.run_id == "body_run"


### PR DESCRIPTION
### What

Airflow's audit log (`Log`) carries `dag_id` / `task_id` / `run_id` columns that the
event-log API filters, sorts and displays entries by. `action_logging` populated those
columns by merging the raw request body over the route's path and query parameters, so an
entry's attribution could be taken from arbitrary body or query keys the route never
declared. On the routes where the logging dependency was ordered before the authorization
dependency, an entry was also written for a request that was then rejected.

Either way an audit entry could end up naming a Dag / task / run the request did not
legitimately act on, which is misleading for anyone reading the log for operational or
compliance purposes.

### Change

- Populate the attribution columns from the route's **path parameters** only — these are
  fixed by the URL template, so they reflect the resource the route actually addressed.
- Add an explicit `body_attribution_fields` opt-in on `action_logging` for the few routes
  that legitimately carry an identifier only in the body: `create_backfill` (`dag_id`),
  `trigger_dag_run` and `post_clear_task_instances` (`dag_run_id`), and
  `clear_dag_run_partitions` (`run_id`). A path parameter always wins over an opted-in
  body field.
- Run the logging dependency **after** authorization on the two opt-in routes that were
  ordered before it (`create_backfill`, `post_clear_task_instances`), so a body-supplied
  identifier is recorded only once the request is authorized.
- The full (masked) request body is still stored in the entry's `extra` field, so nothing
  is dropped from the record.

### Tests

`airflow-core/tests/unit/api_fastapi/logging/test_decorators.py` gains direct coverage:
attribution comes from path params; the body and query string cannot set the columns; an
opted-in body field fills a column the path does not carry; and a path parameter is never
overridden by an opted-in body field. Existing route suites (backfills, Dag run
trigger/clear/partitions, clear task instances, connections, pools, variables, xcom,
event logs, HITL) pass unchanged.

---

Generated-by: Claude Code (Fable 5)
